### PR TITLE
Add logging frontend errors to decky logging

### DIFF
--- a/main.py
+++ b/main.py
@@ -21,6 +21,7 @@ class Plugin:
             )
             return {"status": "success", "output": result.stdout}
         except subprocess.CalledProcessError as e:
+            decky.logger.error(e.output)
             return {"status": "error", "message": str(e), "output": e.output}
 
     async def run_install_fgmod(self) -> dict:
@@ -141,4 +142,9 @@ class Plugin:
             return {"status": "success", "games": filtered_games}
 
         except Exception as e:
+            decky.logger.error(str(e))
             return {"status": "error", "message": str(e)}
+
+    async def log_error(self, error: str) -> None:
+        decky.logger.error(f"FRONTEND: {error}")
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decky-framegen",
-  "version": "0.6.0",
+  "version": "0.7.1",
   "description": "plugin to swap DLSS with FSR, to enable upscaling and framegen in games without built in FSR.",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
* Adds some logging of failure points in the frontend to decky plugin's logging.
* Changed the `{boolean && (<ReactElement>)}` patterns to `{boolean ? (<ReactElement>) : null}` which is the expected for React.