### PR TITLE
testing xess 2.1 dll swap in

### DIFF
--- a/main.py
+++ b/main.py
@@ -173,6 +173,26 @@ class Plugin:
             ini_file = extract_path / "OptiScaler.ini"
             self._modify_optiscaler_ini(ini_file)
             
+            # After extraction, replace XeSS DLLs with newer versions from remote binaries (if available)
+            try:
+                newer_libxess = bin_path / "libxess.dll"
+                newer_libxess_dx11 = bin_path / "libxess_dx11.dll"
+                replaced = []
+                if newer_libxess.exists():
+                    shutil.copy2(newer_libxess, extract_path / "libxess.dll")
+                    replaced.append("libxess.dll")
+                else:
+                    decky.logger.warning(f"Newer libxess.dll not found at {newer_libxess}")
+                if newer_libxess_dx11.exists():
+                    shutil.copy2(newer_libxess_dx11, extract_path / "libxess_dx11.dll")
+                    replaced.append("libxess_dx11.dll")
+                else:
+                    decky.logger.warning(f"Newer libxess_dx11.dll not found at {newer_libxess_dx11}")
+                if replaced:
+                    decky.logger.info(f"Replaced XeSS DLLs with newer versions: {', '.join(replaced)}")
+            except Exception as e:
+                decky.logger.error(f"Failed to replace XeSS DLLs: {e}")
+            
             return {
                 "status": "success",
                 "message": f"Successfully extracted OptiScaler {version} to ~/fgmod",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decky-framegen",
-  "version": "0.11.10",
+  "version": "0.11.11",
   "description": "This plugin installs and manages OptiScaler, a tool that enhances upscaling and enables frame generation in a range of DirectX 12 games.",
   "type": "module",
   "scripts": {
@@ -57,7 +57,17 @@
         "name": "BUNDLE_OptiScaler_v0.7.7-pre13_20250731-20250804-002946.7z",
         "url": "https://github.com/xXJSONDeruloXx/OptiScaler-Bleeding-Edge/releases/download/BUNDLE_OptiScaler_v0.7.7-pre13_20250731-20250804-002946/BUNDLE_OptiScaler_v0.7.7-pre13_20250731-20250804-002946.7z",
         "size": 61144853
-    }
+  },
+  {
+    "name": "libxess.dll",
+    "url": "https://github.com/xXJSONDeruloXx/xess-dlls/releases/download/20250808-142556/libxess.dll",
+    "sha256hash": "a49f487f15a815c1242b659182cc9365b6aff2d94051d25d5379316bdb11a2dd"
+  },
+  {
+    "name": "libxess_dx11.dll",
+    "url": "https://github.com/xXJSONDeruloXx/xess-dlls/releases/download/20250808-142556/libxess_dx11.dll",
+    "sha256hash": "249c87dea58aa9d6f6b5309d5acaf6b95e77bb8055735a3f162e3d24af086733"
+  }
   ]
 }
 


### PR DESCRIPTION
leverage xess 2.1 dll instead of bundled 2.0 ones from upstream opti. experimental

After extraction completes and OptiScaler.ini tweaks are applied, copy:
bin/libxess.dll -> ~/fgmod/libxess.dll
bin/libxess_dx11.dll -> ~/fgmod/libxess_dx11.dll

verwrites existing files and logs what was replaced. 