### PR TITLE
Fix Steam process tracking - remove exec and filter -- separators

### DIFF
--- a/defaults/assets/fgmod.sh
+++ b/defaults/assets/fgmod.sh
@@ -68,7 +68,7 @@ for arg in "$@"; do
     fi
 
     # Extract executable path from YAML
-    exe_path=$(grep -E '^\s*exe:' "$config_file" | sed 's/.*exe:[[:space:]]*//')
+    exe_path=$(grep -E '^\s*exe:' "$config_file" | sed 's/.*exe:[[:space:]]*//' )
 
     if [[ -n "$exe_path" ]]; then
       exe_folder_path=$(dirname "$exe_path")
@@ -187,7 +187,13 @@ if [[ $# -gt 1 ]]; then
   # Execute the original command
   export SteamDeck=0
   export WINEDLLOVERRIDES="$WINEDLLOVERRIDES,dxgi=n,b"
-  exec "$@"
+
+  # Filter out leading -- separators (from Steam launch options)
+  while [[ $# -gt 0 && "$1" == "--" ]]; do
+    shift
+  done
+
+  "$@"
 else
   echo "Done!"
   echo "----------------------------------------"


### PR DESCRIPTION
Steam process tracking requires:
1. Remove 'exec' from command execution (use direct call)
2. Filter out leading -- separators from launch options
3. Add trailing space to sed command (Lutris fix)

Applied to defaults/assets/fgmod.sh

Credit: https://github.com/benjamimgois/goverlay/commit/72d38b10a7710e628fef731eb4f9f335a4d80bd2