### PR TITLE
Fix uninstaller causing game file corruption on second launch

### DIFF
--- a/defaults/assets/fgmod-uninstaller.sh
+++ b/defaults/assets/fgmod-uninstaller.sh
@@ -115,8 +115,16 @@ rm -f "nvapi64.dll" "fakenvapi.ini" "fakenvapi.log"
 
 # === Remove Supporting Libraries ===
 echo "🧹 Removing supporting libraries..."
-rm -f "libxess.dll" "libxess_dx11.dll" "libxess_fg.dll" "libxell.dll" "nvngx.dll" "nvngx.ini"
-rm -f "amd_fidelityfx_dx12.dll" "amd_fidelityfx_framegeneration_dx12.dll" "amd_fidelityfx_upscaler_dx12.dll" "amd_fidelityfx_vk.dll"
+rm -f "nvngx.dll" "nvngx.ini"
+# Only remove files if backups exist (to avoid removing restored originals)
+[[ -f "libxess.dll.b" ]] && rm -f "libxess.dll"
+[[ -f "libxess_dx11.dll.b" ]] && rm -f "libxess_dx11.dll"
+[[ -f "libxess_fg.dll.b" ]] && rm -f "libxess_fg.dll"
+[[ -f "libxell.dll.b" ]] && rm -f "libxell.dll"
+[[ -f "amd_fidelityfx_dx12.dll.b" ]] && rm -f "amd_fidelityfx_dx12.dll"
+[[ -f "amd_fidelityfx_framegeneration_dx12.dll.b" ]] && rm -f "amd_fidelityfx_framegeneration_dx12.dll"
+[[ -f "amd_fidelityfx_upscaler_dx12.dll.b" ]] && rm -f "amd_fidelityfx_upscaler_dx12.dll"
+[[ -f "amd_fidelityfx_vk.dll.b" ]] && rm -f "amd_fidelityfx_vk.dll"
 
 # === Remove FG Mod Files ===
 echo "🧹 Removing frame generation mod files..."


### PR DESCRIPTION
Hi again, I'm sorry for posting so many PRs in such a short time, I'm developping a decky plugin to manage launch options which I test mostly with Decky LSFG-VK and Decky Framegen since I want to use it with them... :sob: 

There's an issue that I noticed when developing that drove me crazy and I didn't understand why until today. Sometimes games I just installed would fail to launch, sometimes without errors or the errors were unclear. Cyberpunk just exits while Lort just displays an unrelated error for example. Whenever I would enable Decky Framegen, the error would go away and whenever I uninstalled it right after it would still work so that was confusing but it would break again if I tried to launch it a third time.

The way my plugin works is that I can set a On and Off value where I would put the installer in the On value and the uninstaller in the Off value to toggle between those quickly. This meant if I didn't enable Decky Framegen, the uninstaller could run more than once (once every game launch). 

I took a look at the uninstaller script and I realized that some files are removed without checking if backup files existed which caused the second launch of the game to remove those files and corrupt the installation.

I added a check for each file included in the list of original_dlls before they're being removed and now the issue is solved.

Looking at issues this should:
Fix #101 , fix #40, fix #63, fix #105, fix #129

Tested from tag v0.30.0
Here's a build with the provided fix: https://github.com/Wurielle/Decky-Framegen/releases/tag/v0.13.0-next.3