### PR TITLE
Update OptiScaler to v0.9.4 final

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,21 @@ Dx12Upscaler=fsr31 ~/fgmod/fgmod %command%
 - Environment variables override the OptiScaler.ini file on each game launch
 - Hyphenated section names like `[V-Sync]` can be accessed like `VSync_Option=value`
 - If an option name appears in multiple sections of the OptiScaler.ini file, use the `Section_Option` or `OptiScaler_Section_Option` format
+- OptiScaler 0.9.4 adds `FSR_Fsr4ForceEnableInt8=true` for the bundled SDK upscaler. It can force INT8 on unsupported GPUs that support INT8, but does not make older non-INT8 hardware compatible and does not affect the `amdxcffx64.dll` driver override. Enable `FSR_Fsr4EnableWatermark=true` to verify the active FSR runtime.
+
+### Choosing an FSR4 Runtime
+
+- **4.1.1 FFX 2.3 SDK**: The upstream 0.9.4 bundled path. Official FSR4 support is RDNA4 (FP8) and RDNA3 desktop GPUs (INT8); it is the only bundled path affected by `Fsr4ForceEnableInt8`.
+- **4.1.1 Valve RDNA2 Compatibility**: The RDNA2 compatibility option. It uses the final SDK upscaler with the Valve `amdxcffx64.dll`, `amdxc64.dll`, the pre10 OptiScaler injector, and RDNA2-specific INI overrides.
+- **4.1.1 Driver Override**: Uses the same final SDK upscaler plus a separate `amdxcffx64.dll` AMD driver provider. It is a fallback/testing path and is not bundled by upstream 0.9.4.
+- **4.0.2c RDNA2/3 Compatibility**: Older compatibility runtime. Prefer the Valve 4.1.1 path for RDNA2 or the regular 4.1.1 driver override when those work for the game.
+
+FSR 4.1.1 can fall back internally to FSR3 on unsupported hardware. Check the FSR4 watermark (`FSR4`, `FSR4-i8`, or `FSR3`) after changing a runtime to confirm the active path.
 
 ## Technical Details
 
 ### What's Included
-- **[OptiScaler 0.9.3](https://github.com/optiscaler/OptiScaler/releases/tag/v0.9.3)**: Official upstream OptiScaler bundle used by this plugin, with bundled FSR4 runtime variants for the archive-native RDNA4 path, the Steam Deck / RDNA2-3 optimized INT8 override, the official 4.1.1 RDNA 3/4 override, or the experimental Valve 4.1.1 RDNA2 compatibility path with a pre10 OptiScaler injector
+- **[OptiScaler 0.9.4](https://github.com/optiscaler/OptiScaler/releases/tag/v0.9.4)**: Official upstream final bundle with the FFX 2.3 SDK / FSR4.1.1. The plugin retains its separately bundled FSR4.0.2c compatibility runtime and existing 4.1.1 driver-override variants; the final upstream archive itself does not include those driver-override DLLs.
 - **Nukem9's DLSSG to FSR3 mod**: Allows use of DLSS inputs for FSR frame gen outputs, and xess or FSR upscaling outputs
 - **FakeNVAPI**: NVIDIA API emulation for AMD/Intel GPUs, to make DLSS options selectable in game
 - **Supporting Libraries**: All required DX12/Vulkan libraries (libxess.dll, amd_fidelityfx, etc.)

--- a/defaults/assets/fgmod-uninstaller.sh
+++ b/defaults/assets/fgmod-uninstaller.sh
@@ -115,7 +115,7 @@ rm -f "nvapi64.dll" "fakenvapi.ini" "fakenvapi.log"
 
 # === Remove Supporting Libraries ===
 echo " Removing supporting libraries..."
-rm -f "nvngx.dll" "nvngx.ini" "amdxcffx64.dll"
+rm -f "nvngx.dll" "nvngx.ini" "amdxcffx64.dll" "amdxc64.dll"
 # Only remove files if backups exist (to avoid removing restored originals)
 [[ -f "libxess.dll.b" ]] && rm -f "libxess.dll"
 [[ -f "libxess_dx11.dll.b" ]] && rm -f "libxess_dx11.dll"
@@ -125,6 +125,7 @@ rm -f "nvngx.dll" "nvngx.ini" "amdxcffx64.dll"
 [[ -f "amd_fidelityfx_framegeneration_dx12.dll.b" ]] && rm -f "amd_fidelityfx_framegeneration_dx12.dll"
 [[ -f "amd_fidelityfx_upscaler_dx12.dll.b" ]] && rm -f "amd_fidelityfx_upscaler_dx12.dll"
 [[ -f "amdxcffx64.dll.b" ]] && rm -f "amdxcffx64.dll"
+[[ -f "amdxc64.dll.b" ]] && rm -f "amdxc64.dll"
 [[ -f "amd_fidelityfx_vk.dll.b" ]] && rm -f "amd_fidelityfx_vk.dll"
 
 # === Remove FG Mod Files ===
@@ -151,7 +152,7 @@ rm -f "dlssg_to_fsr3_amd_is_better-3.0.dll"
 
 # === Restore Original DLLs ===
 echo " Restoring original DLLs..."
-restorable_dlls=("dxgi.dll" "winmm.dll" "dbghelp.dll" "version.dll" "wininet.dll" "winhttp.dll" "OptiScaler.asi" "d3dcompiler_47.dll" "amd_fidelityfx_dx12.dll" "amd_fidelityfx_framegeneration_dx12.dll" "amd_fidelityfx_upscaler_dx12.dll" "amdxcffx64.dll" "amd_fidelityfx_vk.dll" "libxess.dll" "libxess_dx11.dll" "libxess_fg.dll" "libxell.dll")
+restorable_dlls=("dxgi.dll" "winmm.dll" "dbghelp.dll" "version.dll" "wininet.dll" "winhttp.dll" "OptiScaler.asi" "d3dcompiler_47.dll" "amd_fidelityfx_dx12.dll" "amd_fidelityfx_framegeneration_dx12.dll" "amd_fidelityfx_upscaler_dx12.dll" "amdxcffx64.dll" "amdxc64.dll" "amd_fidelityfx_vk.dll" "libxess.dll" "libxess_dx11.dll" "libxess_fg.dll" "libxell.dll")
 for dll in "${restorable_dlls[@]}"; do
   if [[ -f "${dll}.b" ]]; then
     mv "${dll}.b" "$dll"

--- a/main.py
+++ b/main.py
@@ -10,9 +10,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 OPTISCALER_ARCHIVE_ASSET = {
-    "name": "Optiscaler_0.9.4-pre1.20260623.7z",
-    "sha256": "02b407d69a7372ada6eaa8db2c835e9432a9ec436ffe8eea34eecf9c5f6c240c",
-    "version": "0.9.4-pre1.20260623",
+    "name": "Optiscaler_0.9.4-final.20260718._MM.7z",
+    "sha256": "575cb4df866116093df75af607e37fd70e10f5163e0f23fd5c804142e80ef0ad",
+    "version": "0.9.4-final.20260718",
 }
 
 FSR4_INT8_ASSET = {
@@ -59,7 +59,7 @@ DEFAULT_FSR4_VARIANT = "rdna23-int8"
 
 FSR4_VARIANTS = {
     "rdna23-int8": {
-        "label": "Steam Deck / RDNA2-3 optimized",
+        "label": "4.0.2c / RDNA2-3 compatibility",
         "dir_name": "fsr4-rdna2-3",
         "sha256": "c7720bc16bede334f59a1a32cd22edbcbbb159685ed5240e61350a5fb0bc8a94",
         "source_asset_name": FSR4_INT8_ASSET["name"],
@@ -68,18 +68,18 @@ FSR4_VARIANTS = {
         "extra_files": [],
     },
     "rdna4-native": {
-        "label": "Native bundle / RDNA4",
+        "label": "4.1.1 SDK / RDNA3 dGPU + RDNA4",
         "dir_name": "fsr4-rdna4",
-        "sha256": "ec7ed3ca674e288240e6f04b986342aece47454c41d9b0959449e82e22bd7f6d",
+        "sha256": "d0dcccc74a43c44ba435b7a369b456e0970d8a4464e4bd683119b374f2c9fb46",
         "source_asset_name": OPTISCALER_ARCHIVE_ASSET["name"],
         "source_version": OPTISCALER_ARCHIVE_ASSET["version"],
         "uses_archive_native": True,
         "extra_files": [],
     },
     "rdna34-official-411": {
-        "label": "4.1.1 official for RDNA 3/4",
+        "label": "4.1.1 driver override / RDNA3-4",
         "dir_name": "fsr4-rdna3-4-official-411",
-        "sha256": "ec7ed3ca674e288240e6f04b986342aece47454c41d9b0959449e82e22bd7f6d",
+        "sha256": "d0dcccc74a43c44ba435b7a369b456e0970d8a4464e4bd683119b374f2c9fb46",
         "source_asset_name": OPTISCALER_ARCHIVE_ASSET["name"],
         "source_version": OPTISCALER_ARCHIVE_ASSET["version"],
         "uses_archive_native": True,
@@ -96,7 +96,7 @@ FSR4_VARIANTS = {
     "rdna2-valve-411-pre10": {
         "label": "4.1.1 Valve RDNA2 compatibility",
         "dir_name": "fsr4-rdna2-valve-411-pre10",
-        "sha256": "ec7ed3ca674e288240e6f04b986342aece47454c41d9b0959449e82e22bd7f6d",
+        "sha256": "d0dcccc74a43c44ba435b7a369b456e0970d8a4464e4bd683119b374f2c9fb46",
         "source_asset_name": OPTISCALER_ARCHIVE_ASSET["name"],
         "source_version": OPTISCALER_ARCHIVE_ASSET["version"],
         "uses_archive_native": True,

--- a/package.json
+++ b/package.json
@@ -54,9 +54,9 @@
   "remote_binary": 
   [
     {
-      "sha256hash":  "02b407d69a7372ada6eaa8db2c835e9432a9ec436ffe8eea34eecf9c5f6c240c",
-      "url":  "https://github.com/xXJSONDeruloXx/OptiScaler-Bleeding-Edge/releases/download/opti-0.9.4-pre1/Optiscaler_0.9.4-pre1.20260623.7z",
-      "name":  "Optiscaler_0.9.4-pre1.20260623.7z"
+      "sha256hash":  "575cb4df866116093df75af607e37fd70e10f5163e0f23fd5c804142e80ef0ad",
+      "url":  "https://github.com/optiscaler/OptiScaler/releases/download/v0.9.4/Optiscaler_0.9.4-final.20260718._MM.7z",
+      "name":  "Optiscaler_0.9.4-final.20260718._MM.7z"
     },
     {
       "sha256hash": "c7720bc16bede334f59a1a32cd22edbcbbb159685ed5240e61350a5fb0bc8a94",

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -62,23 +62,23 @@ export const DEFAULT_PROXY_DLL: ProxyDllValue = "dxgi.dll";
 export const FSR4_VARIANT_OPTIONS = [
   {
     value: "rdna23-int8",
-    label: "4.0.2c | RDNA2/3 Mod",
-    hint: "Uses the bundled FSR4 INT8 4.0.2c override. Recommended for Steam Deck and other non-RDNA4 systems.",
+    label: "4.0.2c | RDNA2/3 Compatibility",
+    hint: "Older compatible runtime for RDNA2/3. In most cases, use the Valve 4.1.1 path for RDNA2 or the regular 4.1.1 driver override.",
   },
   {
     value: "rdna4-native",
-    label: "4.1.0 | RDNA4 Official",
-    hint: "Uses the AMD-supplied 4.1.0 amd_fidelityfx_upscaler_dx12.dll redistributed in the OptiScaler bundle.",
+    label: "4.1.1 | FFX 2.3 SDK",
+    hint: "Uses OptiScaler 0.9.4's bundled FSR4.1.1 SDK upscaler. Official FSR4 support is RDNA4 (FP8) and RDNA3 desktop GPUs (INT8).",
   },
   {
     value: "rdna34-official-411",
-    label: "4.1.1 | RDNA3/4 Official",
-    hint: "Uses the 4.1.0 native upscaler plus the official 4.1.1 amdxcffx64.dll override for RDNA 3/4.",
+    label: "4.1.1 | Driver Override",
+    hint: "Uses the final bundled FSR4.1.1 SDK upscaler plus the separately bundled 4.1.1 amdxcffx64.dll driver override.",
   },
   {
     value: "rdna2-valve-411-pre10",
-    label: "4.1.1 | RDNA2 Mod",
-    hint: "Uses the pre10 OptiScaler injector, 4.1.0 native upscaler, Valve 4.1.1 amdxcffx64.dll, old amdxc64.dll, and RDNA2-specific INI overrides.",
+    label: "4.1.1 | Valve RDNA2 Compatibility",
+    hint: "Uses the final bundled FSR4.1.1 SDK upscaler with the existing pre10 injector, Valve 4.1.1 amdxcffx64.dll, amdxc64.dll, and RDNA2-specific INI overrides.",
   },
 ] as const;
 


### PR DESCRIPTION
- replace the mirrored 0.9.4 pre-release archive with the verified official v0.9.4 final asset
- update the FFX 2.3 / FSR 4.1.1 SDK runtime hash and runtime-selection labels
- retain explicit compatibility paths for the existing driver-override and Valve RDNA2 runtimes
- restore `amdxc64.dll` correctly during launcher-script uninstall
- document FSR4 runtime selection, INT8 scope, and watermark verification
